### PR TITLE
[homebridge] Usage `:latest`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   homebridge:
     container_name: homebridge
     restart: unless-stopped
-    image: "afharo/homebridge:8"
+    image: "afharo/homebridge:latest"
     volumes:
       - ./data/homebridge:/root/.homebridge
     env_file:


### PR DESCRIPTION
I cannot leverage Renovate to update the version of my private docker image in the docker-compose because I cannot set the login details to the Docker Repository in the Repository version.

I'd rather run `docker compose pull` in the terminal whenever I know there's a new version of my own image than manually updating this repo all the time :lazy: