### PR TITLE
[HASS] Mount DBus service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,7 @@ services:
     volumes:
       - ./data/homeassistant:/config
       - /etc/localtime:/etc/localtime:ro
+      - /run/dbus:/run/dbus:ro # Necessary for the Bluetooth integration
     privileged: true
     network_mode: host
     logging:


### PR DESCRIPTION
HASS shows this warning in the logs:

```
homeassistant    | 2023-08-21 00:59:17.540 WARNING (MainThread) [homeassistant.config_entries] Config entry '38:89:XX:XX:XX:XX' for bluetooth integration not ready yet: hci0 (38:89:XX:XX:XX:XX): DBus service not found; docker config may be missing `-v /run/dbus:/run/dbus:ro`: {ex}; Retrying in background
```