### PR TITLE
Add access to ghcr.io

### DIFF
--- a/.github/renovate/config.js
+++ b/.github/renovate/config.js
@@ -4,9 +4,15 @@ module.exports = {
   repositories: [ "afharo/dockerized-smarthome" ],
   hostRules: [
     {
-      hostType: 'docker',
+      hostType: "docker",
       username: process.env.DOCKER_HUB_USER,
       password: process.env.DOCKER_HUB_PASSWORD,
+    },
+
+    // Explicitly declaring the GH docker registry to avoid using the default "token-based authentication" (that's failing)
+    {
+      hostType: "docker",
+      matchHost: "ghcr.io",
     },
   ],
 };


### PR DESCRIPTION
Attempt to fix

---

> [!WARNING]
> Renovate failed to look up the following dependencies: `Failed to look up docker package ghcr.io/home-assistant-libs/python-matter-server`.
> 
> Files affected: `docker-compose.yml`

---