### PR TITLE
Revert "chore(deps): update ghcr.io/home-assistant-libs/python-matter-server docker tag to v6"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
         max-file: "1"
 
   matter-server:
-    image: ghcr.io/home-assistant-libs/python-matter-server:6.0.0
+    image: ghcr.io/home-assistant-libs/python-matter-server:5.10.0
     container_name: matter-server
     restart: unless-stopped
     # Required for mDNS to work correctly


### PR DESCRIPTION
This reverts commit 2ed3068f0794411c1b53c7ead24d12de9dbfb7f7.

Reason: https://github.com/home-assistant-libs/python-matter-server/issues/704