### PR TITLE
Revert "chore(deps): update koenkk/zigbee2mqtt docker tag to v1.41.0"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
   zigbee2mqtt:
     container_name: zigbee2mqtt
     restart: unless-stopped
-    image: koenkk/zigbee2mqtt:1.41.0
+    image: koenkk/zigbee2mqtt:1.40.2
     volumes:
       - ./data/zigbee2mqtt:/app/data
       - /run/udev:/run/udev:ro


### PR DESCRIPTION
This reverts commit 6a5b8fefcc27fa5e62914645a02f54ecb8e3dc67.

Related to https://github.com/Koenkk/zigbee2mqtt/issues/23483